### PR TITLE
Add C API status constants in tf_status.h

### DIFF
--- a/docs/tensorflow.html
+++ b/docs/tensorflow.html
@@ -1199,6 +1199,80 @@
 </li></ul>
 
 
+<a name="C-API-status-constants-in-tf_status"></a>
+<h3 class="subheading">C API status constants in tf_status.h </h3>
+<ul>
+<li> <code>'TF_OK'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_OK. 
+</li></ul>
+<li> <code>'TF_CANCELLED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_CANCELLED. 
+</li></ul>
+<li> <code>'TF_UNKNOWN'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_UNKNOWN. 
+</li></ul>
+<li> <code>'TF_INVALID_ARGUMENT'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_INVALID_ARGUMENT. 
+</li></ul>
+<li> <code>'TF_DEADLINE_EXCEEDED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_DEADLINE_EXCEEDED. 
+</li></ul>
+<li> <code>'TF_NOT_FOUND'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_NOT_FOUND. 
+</li></ul>
+<li> <code>'TF_ALREADY_EXISTS'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_ALREADY_EXISTS. 
+</li></ul>
+<li> <code>'TF_PERMISSION_DENIED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_PERMISSION_DENIED. 
+</li></ul>
+<li> <code>'TF_UNAUTHENTICATED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_UNAUTHENTICATED. 
+</li></ul>
+<li> <code>'TF_RESOURCE_EXHAUSTED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_RESOURCE_EXHAUSTED. 
+</li></ul>
+<li> <code>'TF_FAILED_PRECONDITION'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_FAILED_PRECONDITION. 
+</li></ul>
+<li> <code>'TF_ABORTED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_ABORTED. 
+</li></ul>
+<li> <code>'TF_OUT_OF_RANGE'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_OUT_OF_RANGE. 
+</li></ul>
+<li> <code>'TF_UNIMPLEMENTED'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_UNIMPLEMENTED. 
+</li></ul>
+<li> <code>'TF_INTERNAL'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_INTERNAL. 
+</li></ul>
+<li> <code>'TF_UNAVAILABLE'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_UNAVAILABLE. 
+</li></ul>
+<li> <code>'TF_DATA_LOSS'</code> 
+<ul>
+<li> <var>out</var> : scalar <code>uint32</code> size of TF_DATA_LOSS. 
+</li></ul>
+
+</li></ul>
+
 
 <p><strong>Source Code: </strong>
   <a href="https://github.com/pr0m1th3as/tensorflow/tree/main/src/tensorflow.cc">tensorflow</a>

--- a/src/OCT_TF_Status.cc
+++ b/src/OCT_TF_Status.cc
@@ -1,5 +1,6 @@
 /*
 Copyright (C) 2024 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+Copyright (C) 2024 Linux BCKP <linuxbckp@gmail.com>
 
 This file is part of the statistics package for GNU Octave.
 
@@ -213,5 +214,145 @@ octave_value OCT_TF_Message (OCT_ARGS)
   const char* msg = TF_Message (status);
   charMatrix msg_ = msg;
   octave_value plhs = msg_;
+  return plhs;
+}
+
+// -----------------------------------------------------------------------------
+// C API status constants in tf_status.h
+// -----------------------------------------------------------------------------
+
+// #define TF_OK TSL_OK
+octave_value OCT_TF_OK (void)
+{
+  octave_uint32 st = TF_OK;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_CANCELLED TSL_CANCELLED
+octave_value OCT_TF_CANCELLED (void)
+{
+  octave_uint32 st = TF_CANCELLED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_UNKNOWN TSL_UNKNOWN
+octave_value OCT_TF_UNKNOWN (void)
+{
+  octave_uint32 st = TF_UNKNOWN;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_INVALID_ARGUMENT TSL_INVALID_ARGUMENT
+octave_value OCT_TF_INVALID_ARGUMENT (void)
+{
+  octave_uint32 st = TF_INVALID_ARGUMENT;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_DEADLINE_EXCEEDED TSL_DEADLINE_EXCEEDED
+octave_value OCT_TF_DEADLINE_EXCEEDED (void)
+{
+  octave_uint32 st = TF_DEADLINE_EXCEEDED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_NOT_FOUND TSL_NOT_FOUND
+octave_value OCT_TF_NOT_FOUND (void)
+{
+  octave_uint32 st = TF_NOT_FOUND;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_ALREADY_EXISTS TSL_ALREADY_EXISTS
+octave_value OCT_TF_ALREADY_EXISTS (void)
+{
+  octave_uint32 st = TF_ALREADY_EXISTS;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_PERMISSION_DENIED TSL_PERMISSION_DENIED
+octave_value OCT_TF_PERMISSION_DENIED (void)
+{
+  octave_uint32 st = TF_PERMISSION_DENIED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_UNAUTHENTICATED TSL_UNAUTHENTICATED
+octave_value OCT_TF_UNAUTHENTICATED (void)
+{
+  octave_uint32 st = TF_UNAUTHENTICATED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_RESOURCE_EXHAUSTED TSL_RESOURCE_EXHAUSTED
+octave_value OCT_TF_RESOURCE_EXHAUSTED (void)
+{
+  octave_uint32 st = TF_RESOURCE_EXHAUSTED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_FAILED_PRECONDITION TSL_FAILED_PRECONDITION
+octave_value OCT_TF_FAILED_PRECONDITION (void)
+{
+  octave_uint32 st = TF_FAILED_PRECONDITION;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_ABORTED TSL_ABORTED
+octave_value OCT_TF_ABORTED (void)
+{
+  octave_uint32 st = TF_ABORTED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_OUT_OF_RANGE TSL_OUT_OF_RANGE
+octave_value OCT_TF_OUT_OF_RANGE (void)
+{
+  octave_uint32 st = TF_OUT_OF_RANGE;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_UNIMPLEMENTED TSL_UNIMPLEMENTED
+octave_value OCT_TF_UNIMPLEMENTED (void)
+{
+  octave_uint32 st = TF_UNIMPLEMENTED;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_INTERNAL TSL_INTERNAL
+octave_value OCT_TF_INTERNAL (void)
+{
+  octave_uint32 st = TF_INTERNAL;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_UNAVAILABLE TSL_UNAVAILABLE
+octave_value OCT_TF_UNAVAILABLE (void)
+{
+  octave_uint32 st = TF_UNAVAILABLE;
+  octave_value plhs = st;
+  return plhs;
+}
+
+// #define TF_DATA_LOSS TSL_DATA_LOSS
+octave_value OCT_TF_DATA_LOSS (void)
+{
+  octave_uint32 st = TF_DATA_LOSS;
+  octave_value plhs = st;
   return plhs;
 }

--- a/src/tensorflow.cc
+++ b/src/tensorflow.cc
@@ -1,5 +1,6 @@
 /*
 Copyright (C) 2024 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+Copyright (C) 2024 Linux BCKP <linuxbckp@gmail.com>
 
 This file is part of the statistics package for GNU Octave.
 
@@ -944,6 +945,92 @@ protocol buffer for attribute. \n\
 @end itemize \n\
 @end itemize \n\
 \n\
+@subheading C API status constants in tf_status.h \n\
+@item @qcode{'TF_OK'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_OK. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_CANCELLED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_CANCELLED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_UNKNOWN'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_UNKNOWN. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_INVALID_ARGUMENT'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_INVALID_ARGUMENT. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_DEADLINE_EXCEEDED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_DEADLINE_EXCEEDED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_NOT_FOUND'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_NOT_FOUND. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_ALREADY_EXISTS'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_ALREADY_EXISTS. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_PERMISSION_DENIED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_PERMISSION_DENIED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_UNAUTHENTICATED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_UNAUTHENTICATED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_RESOURCE_EXHAUSTED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_RESOURCE_EXHAUSTED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_FAILED_PRECONDITION'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_FAILED_PRECONDITION. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_ABORTED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_ABORTED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_OUT_OF_RANGE'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_OUT_OF_RANGE. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_UNIMPLEMENTED'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_UNIMPLEMENTED. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_INTERNAL'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_INTERNAL. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_UNAVAILABLE'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_UNAVAILABLE. \n\
+@end itemize \n\
+\n\
+@item @qcode{'TF_DATA_LOSS'} \n\
+@itemize \n\
+@item @var{out} : scalar @code{uint32} size of TF_DATA_LOSS. \n\
+@end itemize \n\
+\n\
 @end deftypefn")
 {
   int nlhs = nargout;
@@ -1443,6 +1530,77 @@ protocol buffer for attribute. \n\
   else if (c_api == "TF_TensorIsAligned")
   {
     plhs = OCT_TF_TensorIsAligned (nrhs, args);
+  }
+  // ---------------------------------------------------------------------------
+  // C API status constants in tf_status.h
+  // ---------------------------------------------------------------------------
+  else if (c_api == "TF_OK")
+  {
+    plhs = OCT_TF_OK ();
+  }
+  else if (c_api == "TF_CANCELLED")
+  {
+    plhs = OCT_TF_CANCELLED ();
+  }
+  else if (c_api == "TF_UNKNOWN")
+  {
+    plhs = OCT_TF_UNKNOWN ();
+  }
+  else if (c_api == "TF_INVALID_ARGUMENT")
+  {
+    plhs = OCT_TF_INVALID_ARGUMENT ();
+  }
+  else if (c_api == "TF_DEADLINE_EXCEEDED")
+  {
+    plhs = OCT_TF_DEADLINE_EXCEEDED ();
+  }
+  else if (c_api == "TF_NOT_FOUND")
+  {
+    plhs = OCT_TF_NOT_FOUND ();
+  }
+  else if (c_api == "TF_ALREADY_EXISTS")
+  {
+    plhs = OCT_TF_ALREADY_EXISTS ();
+  }
+  else if (c_api == "TF_PERMISSION_DENIED")
+  {
+    plhs = OCT_TF_PERMISSION_DENIED ();
+  }
+  else if (c_api == "TF_UNAUTHENTICATED")
+  {
+    plhs = OCT_TF_UNAUTHENTICATED ();
+  }
+  else if (c_api == "TF_RESOURCE_EXHAUSTED")
+  {
+    plhs = OCT_TF_RESOURCE_EXHAUSTED ();
+  }
+  else if (c_api == "TF_FAILED_PRECONDITION")
+  {
+    plhs = OCT_TF_FAILED_PRECONDITION ();
+  }
+  else if (c_api == "TF_ABORTED")
+  {
+    plhs = OCT_TF_ABORTED ();
+  }
+  else if (c_api == "TF_OUT_OF_RANGE")
+  {
+    plhs = OCT_TF_OUT_OF_RANGE ();
+  }
+  else if (c_api == "TF_UNIMPLEMENTED")
+  {
+    plhs = OCT_TF_UNIMPLEMENTED ();
+  }
+  else if (c_api == "TF_INTERNAL")
+  {
+    plhs = OCT_TF_INTERNAL ();
+  }
+  else if (c_api == "TF_UNAVAILABLE")
+  {
+    plhs = OCT_TF_UNAVAILABLE ();
+  }
+  else if (c_api == "TF_DATA_LOSS")
+  {
+    plhs = OCT_TF_DATA_LOSS ();
   }
   // ---------------------------------------------------------------------------
   else

--- a/src/tensorflow.h
+++ b/src/tensorflow.h
@@ -1,5 +1,6 @@
 /*
 Copyright (C) 2024 Andreas Bertsatos <abertsatos@biol.uoa.gr>
+Copyright (C) 2024 Linux BCKP <linuxbckp@gmail.com>
 
 This file is part of the statistics package for GNU Octave.
 
@@ -177,4 +178,24 @@ void OCT_TF_TensorFromProto (OCT_ARGS);
 octave_value OCT_TF_TensorElementCount (OCT_ARGS);
 void OCT_TF_TensorBitcastFrom (OCT_ARGS);
 octave_value OCT_TF_TensorIsAligned (OCT_ARGS);
+// ---------------------------------------------------------------------------
+// C API status constants in tf_status.h
+// ---------------------------------------------------------------------------
+octave_value OCT_TF_OK (void);
+octave_value OCT_TF_CANCELLED (void);
+octave_value OCT_TF_UNKNOWN (void);
+octave_value OCT_TF_INVALID_ARGUMENT (void);
+octave_value OCT_TF_DEADLINE_EXCEEDED (void);
+octave_value OCT_TF_NOT_FOUND (void);
+octave_value OCT_TF_ALREADY_EXISTS (void);
+octave_value OCT_TF_PERMISSION_DENIED (void);
+octave_value OCT_TF_UNAUTHENTICATED (void);
+octave_value OCT_TF_RESOURCE_EXHAUSTED (void);
+octave_value OCT_TF_FAILED_PRECONDITION (void);
+octave_value OCT_TF_ABORTED (void);
+octave_value OCT_TF_OUT_OF_RANGE (void);
+octave_value OCT_TF_UNIMPLEMENTED (void);
+octave_value OCT_TF_INTERNAL (void);
+octave_value OCT_TF_UNAVAILABLE (void);
+octave_value OCT_TF_DATA_LOSS (void);
 #endif // TENSORFLOW_H


### PR DESCRIPTION
octave_value OCT_TF_OK (void);
octave_value OCT_TF_CANCELLED (void);
octave_value OCT_TF_UNKNOWN (void);
octave_value OCT_TF_INVALID_ARGUMENT (void);
octave_value OCT_TF_DEADLINE_EXCEEDED (void);
octave_value OCT_TF_NOT_FOUND (void);
octave_value OCT_TF_ALREADY_EXISTS (void);
octave_value OCT_TF_PERMISSION_DENIED (void);
octave_value OCT_TF_UNAUTHENTICATED (void);
octave_value OCT_TF_RESOURCE_EXHAUSTED (void);
octave_value OCT_TF_FAILED_PRECONDITION (void);
octave_value OCT_TF_ABORTED (void);
octave_value OCT_TF_OUT_OF_RANGE (void);
octave_value OCT_TF_UNIMPLEMENTED (void);
octave_value OCT_TF_INTERNAL (void);
octave_value OCT_TF_UNAVAILABLE (void);
octave_value OCT_TF_DATA_LOSS (void);